### PR TITLE
Fixes due to upstream changes

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -24,7 +24,7 @@
     # This role only works on OMERO 5.3+
     - role: omero-user
       omero_user_bin_omero: /opt/omero/server/OMERO.server/bin/omero
-      omero_user_system: omero
+      omero_user_system: omero-server
       omero_user_admin_user: root
       omero_user_admin_pass: omero
       omero_group_create:

--- a/requirements.yml
+++ b/requirements.yml
@@ -10,7 +10,7 @@
 
 - name: openmicroscopy.omero-server
   src:  https://github.com/manics/ansible-role-omero-server.git
-  version: devel
+  version: devel-20170405
 
 - name: openmicroscopy.omero-web
   src:  https://github.com/manics/ansible-role-omero-web.git


### PR DESCRIPTION
openmicroscopy.ansible-role-omero-server now uses `omero-server` so this will fail if run.

tag changed, from `devel`, switched to the snapshot of devel again to make it run.