### PR TITLE
Fix variable name for postgresql version.

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -39,4 +39,4 @@
 
   vars:
     omero_web_public_password: public
-    postgres_version: "9.6"
+    postgresql_version: "9.6"


### PR DESCRIPTION
As it stands, playbook installs PostgreSQL version 9.4 as the variable name needs updated: cf https://github.com/openmicroscopy/ansible-role-postgresql/blame/master/README.md#L13