### PR TITLE
More example playbooks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,9 @@ install:
   - pip install ome-ansible-molecule-dependencies
 
 script:
-  - molecule test
+  - cd $BASEDIR && molecule test
+
+env:
+  - BASEDIR: .
+  - BASEDIR: allinone
+  - BASEDIR: two-nodes

--- a/README.md
+++ b/README.md
@@ -13,3 +13,9 @@ likely you will want to copy the configuration into your own playbooks.
 - Install `ansible`: e.g. `pip install ansible`
 - Install roles: `ansible-galaxy install -r requirements.yml -p roles`
 - Install OMERO server and setup public user: `ansible-playbook playbook.yml`
+
+
+Other examples
+--------------
+
+This repository also contains two other example playbooks for deploying OMERO with a database, either on the same [`allinone/playbook.yml`](allinone/playbook.yml) or a separate [`two-nodes/playbook.yml`](two-node/playbook.yml) node.

--- a/allinone/inventory
+++ b/allinone/inventory
@@ -1,0 +1,2 @@
+[all]
+omero-allinone ansible_host=192.168.1.1

--- a/allinone/molecule.yml
+++ b/allinone/molecule.yml
@@ -1,0 +1,22 @@
+---
+dependency:
+  name: galaxy
+  requirements_file: requirements.yml
+
+driver:
+  name: docker
+
+docker:
+  containers:
+  - name: omero-allinone
+    image: openmicroscopy/centos-systemd-ip
+    image_version: latest
+    privileged: True
+
+ansible:
+  host_vars:
+    omero-allinone:
+      omero_server_systemd_require_network: False
+
+verifier:
+  name: testinfra

--- a/allinone/playbook.yml
+++ b/allinone/playbook.yml
@@ -12,4 +12,3 @@
       password: omero
       databases: [omero]
     postgresql_version: "9.6"
-    ice_python_wheel: http://users.openmicroscopy.org.uk/~spli/centos-zeroc-ice-py/dist/zeroc_ice-3.6.3-cp27-cp27mu-linux_x86_64.whl

--- a/allinone/playbook.yml
+++ b/allinone/playbook.yml
@@ -1,0 +1,15 @@
+# OMERO single-node deployment
+
+- hosts: omero-allinone
+  roles:
+    - role: openmicroscopy.postgresql
+    - role: openmicroscopy.omero-server
+    - role: openmicroscopy.omero-web
+
+  vars:
+    postgresql_users_databases:
+    - user: omero
+      password: omero
+      databases: [omero]
+    postgresql_version: "9.6"
+    ice_python_wheel: http://users.openmicroscopy.org.uk/~spli/centos-zeroc-ice-py/dist/zeroc_ice-3.6.3-cp27-cp27mu-linux_x86_64.whl

--- a/allinone/requirements.yml
+++ b/allinone/requirements.yml
@@ -1,0 +1,11 @@
+---
+
+- src: openmicroscopy.postgresql
+
+- src: openmicroscopy.omero-common
+
+- src: openmicroscopy.omego
+
+- src: openmicroscopy.omero-server
+
+- src: openmicroscopy.omero-web

--- a/allinone/tests/test_default.py
+++ b/allinone/tests/test_default.py
@@ -1,0 +1,22 @@
+import testinfra.utils.ansible_runner
+import pytest
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    '.molecule/ansible_inventory').get_hosts('all')
+
+OMERO = '/opt/omero/server/OMERO.server/bin/omero'
+
+
+@pytest.mark.parametrize('name', [
+    'omero-server', 'omero-web', 'nginx', 'postgresql-9.6'
+])
+def test_services_running_and_enabled(Service, name):
+    service = Service(name)
+    assert service.is_running
+    assert service.is_enabled
+
+
+def test_omero_login(Command, Sudo):
+    with Sudo('omero-server'):
+        Command.check_output(
+            '%s login -C -s localhost -u root -w omero' % OMERO)

--- a/two-nodes/inventory
+++ b/two-nodes/inventory
@@ -1,0 +1,3 @@
+[all]
+omero-database ansible_host=192.168.1.1
+omero-server ansible_host=192.168.1.2

--- a/two-nodes/molecule.yml
+++ b/two-nodes/molecule.yml
@@ -1,0 +1,26 @@
+---
+dependency:
+  name: galaxy
+  requirements_file: requirements.yml
+
+driver:
+  name: docker
+
+docker:
+  containers:
+  - name: omero-database
+    image: openmicroscopy/centos-systemd-ip
+    image_version: latest
+    privileged: True
+  - name: omero-server
+    image: openmicroscopy/centos-systemd-ip
+    image_version: latest
+    privileged: True
+
+ansible:
+  host_vars:
+    omero-server:
+      omero_server_systemd_require_network: False
+
+verifier:
+  name: testinfra

--- a/two-nodes/playbook.yml
+++ b/two-nodes/playbook.yml
@@ -26,4 +26,3 @@
 
   vars:
     omero_server_dbhost: "{{ hostvars['omero-database'].ansible_eth0.ipv4.address }}"
-    ice_python_wheel: http://users.openmicroscopy.org.uk/~spli/centos-zeroc-ice-py/dist/zeroc_ice-3.6.3-cp27-cp27mu-linux_x86_64.whl

--- a/two-nodes/playbook.yml
+++ b/two-nodes/playbook.yml
@@ -1,0 +1,29 @@
+# Two node deployment:
+# - PostgreSQL database
+# - OMERO.server with OMERO.web
+
+- hosts: omero-database
+  roles:
+    - role: openmicroscopy.postgresql
+
+  vars:
+    postgresql_server_listen: "'*'"
+    postgresql_server_auth:
+    - database: omero
+      user: omero
+      address: 0.0.0.0/0
+    postgresql_users_databases:
+    - user: omero
+      password: omero
+      databases: [omero]
+    postgresql_version: "9.6"
+
+
+- hosts: omero-server
+  roles:
+    - role: openmicroscopy.omero-server
+    - role: openmicroscopy.omero-web
+
+  vars:
+    omero_server_dbhost: "{{ hostvars['omero-database'].ansible_eth0.ipv4.address }}"
+    ice_python_wheel: http://users.openmicroscopy.org.uk/~spli/centos-zeroc-ice-py/dist/zeroc_ice-3.6.3-cp27-cp27mu-linux_x86_64.whl

--- a/two-nodes/requirements.yml
+++ b/two-nodes/requirements.yml
@@ -1,0 +1,11 @@
+---
+
+- src: openmicroscopy.postgresql
+
+- src: openmicroscopy.omero-common
+
+- src: openmicroscopy.omego
+
+- src: openmicroscopy.omero-server
+
+- src: openmicroscopy.omero-web

--- a/two-nodes/tests/test_database.py
+++ b/two-nodes/tests/test_database.py
@@ -1,0 +1,10 @@
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    '.molecule/ansible_inventory').get_hosts('omero-database')
+
+
+def test_services_running_and_enabled(Service):
+    service = Service('postgresql-9.6')
+    assert service.is_running
+    assert service.is_enabled

--- a/two-nodes/tests/test_omero-server.py
+++ b/two-nodes/tests/test_omero-server.py
@@ -1,0 +1,26 @@
+import testinfra.utils.ansible_runner
+import pytest
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    '.molecule/ansible_inventory').get_hosts('omero-server')
+
+OMERO = '/opt/omero/server/OMERO.server/bin/omero'
+
+
+@pytest.mark.parametrize("name", ["omero-server", "omero-web", "nginx"])
+def test_services_running_and_enabled(Service, name):
+    service = Service(name)
+    assert service.is_running
+    assert service.is_enabled
+
+
+def test_postgres_not_installed(Service):
+    service = Service('postgresql-9.6')
+    assert not service.is_running
+    assert not service.is_enabled
+
+
+def test_omero_login(Command, Sudo):
+    with Sudo('omero-server'):
+        Command.check_output(
+            '%s login -C -s localhost -u root -w omero' % OMERO)


### PR DESCRIPTION
Adds two more examples, one without any config (no public user), and one to demonstrate running PostgreSQL on a separate node.

Alternatively I could create two new repos, one for each example.